### PR TITLE
fix get-route-by-user-role func

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -257,6 +257,7 @@ router.beforeEach((to) => {
   if (!user.value && !authRouteNames.includes(currentRouteName)) {
     return { name: 'login' }
   }
+
   if (
     user.value?.role &&
     (authRouteNames.includes(currentRouteName) || currentRouteName === 'home')
@@ -265,6 +266,8 @@ router.beforeEach((to) => {
 
     return getRouteByUserRole(role)
   }
+
+  // ! FIXME CRITICAL: котятки, не забываем обновлять getRouteByUserRole (319 строка), чтобы нормально редиректило, иначе будет критический баг, спасибо))
   if (requiredRouteRoles.length && user.value?.role) {
     const { role } = user.value
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -264,7 +264,6 @@ router.beforeEach((to) => {
   ) {
     const { role } = user.value
 
-    // ! FIXME CRITICAL: котятки, не забываем обновлять getRouteByUserRole, чтобы нормально редиректило, иначе будет критический баг, спасибо))
     return getRouteByUserRole(role)
   }
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -264,10 +264,10 @@ router.beforeEach((to) => {
   ) {
     const { role } = user.value
 
+    // ! FIXME CRITICAL: котятки, не забываем обновлять getRouteByUserRole, чтобы нормально редиректило, иначе будет критический баг, спасибо))
     return getRouteByUserRole(role)
   }
 
-  // ! FIXME CRITICAL: котятки, не забываем обновлять getRouteByUserRole (319 строка), чтобы нормально редиректило, иначе будет критический баг, спасибо))
   if (requiredRouteRoles.length && user.value?.role) {
     const { role } = user.value
 

--- a/src/utils/userRolesInfo.ts
+++ b/src/utils/userRolesInfo.ts
@@ -70,7 +70,7 @@ function getUserRoleInfoStyle(roles: RolesTypes[], index: number) {
   }
 }
 
-// котята, есть смысл в перегрузках, если это можно через юнион сделать??
+// !котятки, не забываем следить за этой функцией, при добовлении новых ролей, чтобы нормально редиректило, иначе будет критический баг, спасибо))
 function getRouteByUserRole(
   currentRole: RolesTypes | RolesTypes[],
 ): RouteLocationRaw {

--- a/src/utils/userRolesInfo.ts
+++ b/src/utils/userRolesInfo.ts
@@ -70,20 +70,23 @@ function getUserRoleInfoStyle(roles: RolesTypes[], index: number) {
   }
 }
 
-function getRouteByUserRole(currentRole: RolesTypes): RouteLocationRaw
-function getRouteByUserRole(currentRoles: RolesTypes[]): RouteLocationRaw
+// котята, есть смысл в перегрузках, если это можно через юнион сделать??
 function getRouteByUserRole(
   currentRole: RolesTypes | RolesTypes[],
 ): RouteLocationRaw {
+  const teamList = ['TEAM_OWNER', 'TEAM_LEADER']
+
   if (currentRole instanceof Array) {
-    if (currentRole.includes('TEAM_OWNER')) {
+    const isTeam = teamList.some((role, index) => role === currentRole[index])
+
+    if (isTeam) {
       return { name: 'teams-list' }
     }
 
     return { name: 'ideas-list' }
   }
 
-  if (currentRole === 'TEAM_OWNER') {
+  if (teamList.includes(currentRole)) {
     return { name: 'teams-list' }
   }
 


### PR DESCRIPTION
добавил team_leader в лист сравнения роли для функции get-route-by-user-role, чтобы редиректило на teams-list
без этой правки пользователь с ролью лидер застревал на странице error, пока не почистит localstorage